### PR TITLE
[#183736970] Add reusable Build workflow for GitHub Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,46 @@
+name: Build
+
+on:
+  workflow_call:
+    inputs:
+      registry:
+        required: true
+        type: string
+      repository:
+        required: true
+        type: string
+    secrets:
+      username:
+        required: true
+      password:
+        required: true
+      build-secrets:
+        required: false
+
+jobs:
+  container-image:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+    steps:
+      - name: Log into ECR
+        uses: docker/login-action@v2.1.0
+        with:
+          registry: ${{ inputs.registry }}
+          username: ${{ secrets.username }}
+          password: ${{ secrets.password }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4.1.1
+        with:
+          images: ${{ inputs.registry }}/${{ inputs.repository }}
+          tags: type=sha
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3.2.0
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          secrets: ${{ secrets.build-secrets }}


### PR DESCRIPTION
Adds a reusable GitHub Actions workflow for building a container image and pushing it to a remote registry. The workflow automatically sets tags and labels based on the git ref, and supports specifying `build-secrets`.

Example usage:

```
jobs:
  build:
    uses: dicksondata/dickson-actions/.github/workflows/build.yaml@e1d48cd9b4a7c10536ce2e5e855cdceeec1a6a14
    with:
      registry: <REGISTRY>
      repository: <REPOSITORY>
    secrets:
      username: ${{ secrets.username }}
      password: ${{ secrets.password }}
```