### PR TITLE
Invert logic for `meta` step in deploy

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -68,7 +68,7 @@ jobs:
         run: gem install krane
 
       - name: Extract Docker metadata
-        if: inputs.version != ''
+        if: inputs.version == ''
         id: meta
         uses: docker/metadata-action@v4.1.1
         with:


### PR DESCRIPTION
We want to run this step specifically if we _don't_ already have a version specified, to populate the outputs for the krane render.