### PR TITLE
Adding a tag workflow

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -1,0 +1,40 @@
+name: Tag
+
+on:
+  workflow_call:
+    inputs:
+      registry:
+        required: true
+        type: string
+      repository:
+        required: true
+        type: string
+    secrets:
+      username:
+        required: true
+      password:
+        required: true
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log into ECR
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ inputs.registry }}
+          username: ${{ secrets.username }}
+          password: ${{ secrets.password }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4.1.1
+        with:
+          images: ${{ inputs.registry }}/${{ inputs.repository }}
+          tags: type=sha
+
+      - name: Add the release as a tag to the Docker image
+        uses: akhilerm/tag-push-action@v2.0.0
+        with:
+          src: ${{ inputs.registry }}/${{ inputs.repository }}:${{ steps.meta.outputs.version }}
+          dst: ${{ inputs.registry }}/${{ inputs.repository }}:${{ github.ref_name }}


### PR DESCRIPTION
The production workflow on dicksonone tags the latest image that was created rather than building a new one. We want to use this same approach in all our other repos, so I'm extracting it here.

The first two steps in this job are the same two steps that are in the build workflow, so we may want to share those. I've not done that in this PR so far, but can do so if we want to go down that route here.
