### PR TITLE
Update default version of kubectl

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -28,7 +28,7 @@ on:
       kubectl-version:
         required: false
         type: string
-        default: v1.22.9
+        default: v1.29.3
     secrets:
       aws-access-key-id:
         required: true


### PR DESCRIPTION
All of our EKS clusters now run Kubernetes 1.28, so we update the default version of `kubectl` installed to be 1.29.3 (Kubernetes supports drift across one minor version, so 1.29 is compatible with 1.28, and is also future-proof for a while longer).