### PR TITLE
Use alpine 3.19 in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -39,7 +39,7 @@ jobs:
   to-kubernetes:
     runs-on: ubuntu-latest
     container:
-      image: ruby:3.1-alpine
+      image: ruby:3.1-alpine3.19
     steps:
       - uses: actions/checkout@v3.1.0
 


### PR DESCRIPTION
Alpine 3.20 was recently released, and as a result `ruby:3.1-alpine` now uses that version of Alpine Linux. However, 3.20 doesn’t include the package `aws-cli`, so we update our version definition to stick with 3.19 until there’s an appropriate package for the new version of Alpine.

I’ve [tested this branch for `dicksonone`](https://github.com/dicksondata/dicksonone/actions/runs/9212387327), and it does fix our deployments.